### PR TITLE
Use Str::plural for Dynamic Table Naming in Models and Migrations

### DIFF
--- a/src/Console/MakeModelCommand.php
+++ b/src/Console/MakeModelCommand.php
@@ -39,7 +39,7 @@ class MakeModelCommand extends Command
 
         $stub = str_replace('{{ ModuleName }}', $this->moduleName, $stub);
         $stub = str_replace('{{ ResourceName }}', $this->resourceName, $stub);
-        $stub = str_replace('{{ resourceName }}', Str::camel($this->resourceName), $stub);
+        $stub = str_replace('{{ resourceName }}', Str::camel(Str::plural($this->resourceName)), $stub);
 
         $path = base_path("modules/{$this->moduleName}/Models/{$this->resourceName}.php");
 

--- a/src/Console/MakeModuleCommand.php
+++ b/src/Console/MakeModuleCommand.php
@@ -34,7 +34,7 @@ class MakeModuleCommand extends Command
             $this->call('modular:make-model', $params);
             $this->call('modular:make-route', $params);
 
-            $this->call('modular:make-migration', ['moduleName' => $this->moduleName, 'migrationName' => "create{$this->moduleName}s_table"]);
+            $this->call('modular:make-migration', ['moduleName' => $this->moduleName, 'migrationName' => 'create'.Str::plural($this->moduleName).'_table']);
             $this->call('modular:make-factory', $params);
 
             $this->call('modular:make-page', $params);

--- a/stubs/module-stub/modules/Models/Model.stub
+++ b/stubs/module-stub/modules/Models/Model.stub
@@ -11,5 +11,5 @@ class {{ ResourceName }} extends BaseModel
 {
     use ActivityLog, Searchable, SoftDeletes;
     
-    protected $table = '{{ resourceName }}s';
+    protected $table = '{{ resourceName }}';
 }


### PR DESCRIPTION
When creating a module (e.g., Company), the migration table name and the protected $table property in the model are incorrectly set to companys instead of companies. This issue occurs because the table name generation logic appends an 's' to the model name, which fails for irregular pluralization.

To fix this, I replaced the static 's' logic with Laravel's Str::plural helper. This change dynamically generates the correct plural form of the table name, ensuring accurate and consistent pluralization for both regular and irregular nouns.