### PR TITLE
Feature(pagination): add fallback values for paginator props

### DIFF
--- a/stubs/page-stub/Index.stub
+++ b/stubs/page-stub/Index.stub
@@ -75,9 +75,9 @@
 
     <AppPaginator
         :links="{{ resourceNameCamelPlural }}.links"
-        :from="{{ resourceNameCamelPlural }}.from"
-        :to="{{ resourceNameCamelPlural }}.to"
-        :total="{{ resourceNameCamelPlural }}.total"
+        :from="{{ resourceNameCamelPlural }}.from || 0"
+        :to="{{ resourceNameCamelPlural }}.to || 0"
+        :total="{{ resourceNameCamelPlural }}.total || 0"
         class="mt-4 justify-center"
     ></AppPaginator>
 


### PR DESCRIPTION
- Updated `<AppPaginator>` component to include fallback values for `from`, `to`, and `total` properties using `|| 0`. 
- Ensures proper rendering and prevents potential errors when these properties are undefined.