### PR TITLE
Feat(console): Add command to create new seeder

### DIFF
--- a/src/Console/MakeSeederCommand.php
+++ b/src/Console/MakeSeederCommand.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Modular\Modular\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Str;
+use Modular\Modular\Console\InstallerTraits\ModuleExists;
+
+class MakeSeederCommand extends Command
+{
+    use ModuleExists;
+
+    protected $signature = 'modular:make-seeder {moduleName} {resourceName}';
+
+    protected $description = 'Create a new seeder class for a Module';
+
+    protected string $moduleName;
+
+    protected string $resourceName;
+
+    public function handle(): int
+    {
+        $this->moduleName = Str::studly($this->argument('moduleName'));
+        $this->resourceName = Str::studly($this->argument('resourceName'));
+
+        if (! $this->moduleExists()) {
+            return self::FAILURE;
+        }
+
+        $this->comment('Module '.$this->moduleName.' found, creating seeder file...');
+        $this->createModuleSeeder();
+
+        return self::SUCCESS;
+    }
+
+    private function createModuleSeeder(): void
+    {
+        (new Filesystem)->ensureDirectoryExists(base_path("modules/{$this->moduleName}/Database/Seeders"));
+
+        $stub = file_get_contents(__DIR__.'/../../stubs/module-stub/modules/Database/Seeders/ModuleSeeder.stub');
+
+        $stub = str_replace('{{ ModuleName }}', $this->moduleName, $stub);
+        $stub = str_replace('{{ ResourceName }}', $this->resourceName, $stub);
+
+        $path = base_path("modules/{$this->moduleName}/Database/Seeders/{$this->resourceName}.php");
+
+        file_put_contents($path, $stub);
+    }
+}

--- a/src/ModularServiceProvider.php
+++ b/src/ModularServiceProvider.php
@@ -13,6 +13,7 @@ use Modular\Modular\Console\MakeModelCommand;
 use Modular\Modular\Console\MakeModuleCommand;
 use Modular\Modular\Console\MakePageCommand;
 use Modular\Modular\Console\MakeRouteCommand;
+use Modular\Modular\Console\MakeSeederCommand;
 use Modular\Modular\Console\MakeServiceCommand;
 use Modular\Modular\Console\MakeTestCommand;
 use Modular\Modular\Console\MakeValidateCommand;
@@ -48,6 +49,7 @@ class ModularServiceProvider extends PackageServiceProvider
             ->hasCommand(MakeComponentCommand::class)
             ->hasCommand(MakeTestCommand::class)
             ->hasCommand(MakeMigrationCommand::class)
+            ->hasCommand(MakeSeederCommand::class)
             ->hasCommand(PublishLaravelTranslationsCommand::class)
             ->hasCommand(PublishSiteFilesCommand::class)
             ->hasCommand(MakeFactoryCommand::class)

--- a/stubs/module-stub/modules/Database/Seeders/ModuleSeeder.stub
+++ b/stubs/module-stub/modules/Database/Seeders/ModuleSeeder.stub
@@ -1,0 +1,17 @@
+<?php
+
+namespace Modules\{{ ModuleName }}\Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class {{ ResourceName }} extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        //
+    }
+}

--- a/stubs/module-stub/modules/ModuleServiceProvider.stub
+++ b/stubs/module-stub/modules/ModuleServiceProvider.stub
@@ -11,6 +11,5 @@ class {{ moduleName }}ServiceProvider extends BaseServiceProvider
         parent::boot();
 
         $this->loadMigrationsFrom(__DIR__.'/Database/Migrations');
-        $this->loadViewsFrom(__DIR__.'/views', '{{ resourceName }}');
     }
 }

--- a/tests/Console/MakeSeederCommandTest.php
+++ b/tests/Console/MakeSeederCommandTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Filesystem\Filesystem;
+
+beforeEach(function () {
+    $this->artisan('modular:make-module ModuleName');
+});
+
+afterEach(function () {
+    (new Filesystem)->deleteDirectory(base_path('modules'));
+});
+
+it('can run modular:make-seeder command', function () {
+    $this->artisan('modular:make-seeder moduleName resourceName')->assertSuccessful();
+});
+
+it('can generate a seeder', function () {
+    $this->artisan('modular:make-seeder moduleName resourceName');
+
+    $seeder = base_path('modules/ModuleName/Database/Seeders/ResourceName.php');
+    $this->assertTrue(file_exists($seeder));
+
+    $seederContent = file_get_contents($seeder);
+
+    expect($seederContent)->toContain('namespace Modules\ModuleName\Database\Seeders;');
+    expect($seederContent)->toContain('class ResourceName extends Seeder');
+});


### PR DESCRIPTION
This PR introduces the artisan command to create a new seeder class file for the specified module.

How does it work?
```sh
$ php artisan modular:make-seeder ModuleName SeederName
```

The new seeder file will be created in the `modules/ModuleName/Database/Seeders/` directory.

The example seeder code is as follows:
```php
<?php

namespace Modules\User\Database\Seeders;

use Illuminate\Database\Console\Seeds\WithoutModelEvents;
use Illuminate\Database\Seeder;

class UserDefaultSeeder extends Seeder
{
    /**
     * Run the database seeds.
     */
    public function run(): void
    {
        //
    }
}
```